### PR TITLE
don't inherit directly from ActiveRecord::Migration

### DIFF
--- a/db/migrate/20150720223311_devise_create_users.rb
+++ b/db/migrate/20150720223311_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table(:users) do |t|
       ## Database authenticatable

--- a/db/migrate/20150725221456_create_choreographers.rb
+++ b/db/migrate/20150725221456_create_choreographers.rb
@@ -1,4 +1,4 @@
-class CreateChoreographers < ActiveRecord::Migration
+class CreateChoreographers < ActiveRecord::Migration[4.2]
   def change
     create_table :choreographers do |t|
       t.string :name

--- a/db/migrate/20150725223759_create_dances.rb
+++ b/db/migrate/20150725223759_create_dances.rb
@@ -1,4 +1,4 @@
-class CreateDances < ActiveRecord::Migration
+class CreateDances < ActiveRecord::Migration[4.2]
   def change
     create_table :dances do |t|
       t.belongs_to :user

--- a/db/migrate/20150809210131_add_name_to_users.rb
+++ b/db/migrate/20150809210131_add_name_to_users.rb
@@ -1,4 +1,4 @@
-class AddNameToUsers < ActiveRecord::Migration
+class AddNameToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :name, :string, limit: 128
   end

--- a/db/migrate/20150811183820_change_figure_types_to_text.rb
+++ b/db/migrate/20150811183820_change_figure_types_to_text.rb
@@ -1,4 +1,4 @@
-class ChangeFigureTypesToText < ActiveRecord::Migration
+class ChangeFigureTypesToText < ActiveRecord::Migration[4.2]
   def change
     # This is likely a one-way trip, see:
     # http://blog.nerdery.com/2013/12/ruby-rails-migrating-string-text-back/

--- a/db/migrate/20151113041305_merge_figures.rb
+++ b/db/migrate/20151113041305_merge_figures.rb
@@ -1,6 +1,6 @@
 require 'json'
 
-class MergeFigures < ActiveRecord::Migration
+class MergeFigures < ActiveRecord::Migration[4.2]
 
   # wat? http://guides.rubyonrails.org/v3.2.21/migrations.html#using-models-in-your-migrations
   class Dance < ActiveRecord::Base

--- a/db/migrate/20151114021434_rename_figures.rb
+++ b/db/migrate/20151114021434_rename_figures.rb
@@ -1,4 +1,4 @@
-class RenameFigures < ActiveRecord::Migration
+class RenameFigures < ActiveRecord::Migration[4.2]
   def change
     rename_column :dances, :figures, :figures_json
   end

--- a/db/migrate/20151206031845_correct_default_value_for_figures_json.rb
+++ b/db/migrate/20151206031845_correct_default_value_for_figures_json.rb
@@ -1,4 +1,4 @@
-class CorrectDefaultValueForFiguresJson < ActiveRecord::Migration
+class CorrectDefaultValueForFiguresJson < ActiveRecord::Migration[4.2]
   def change
     change_column :dances, :figures_json, :text, :null => false, :default => '[]'
   end

--- a/db/migrate/20160106031939_create_programs.rb
+++ b/db/migrate/20160106031939_create_programs.rb
@@ -1,4 +1,4 @@
-class CreatePrograms < ActiveRecord::Migration
+class CreatePrograms < ActiveRecord::Migration[4.2]
   def change
     create_table :programs do |t|
       t.string :title, null: false, limit: 100

--- a/db/migrate/20160107210640_disallow_nulls_in_dances.rb
+++ b/db/migrate/20160107210640_disallow_nulls_in_dances.rb
@@ -1,4 +1,4 @@
-class DisallowNullsInDances < ActiveRecord::Migration
+class DisallowNullsInDances < ActiveRecord::Migration[4.2]
   def up
     change_column(:dances, :title,      :string, default: "", null: false)
     change_column(:dances, :start_type, :string, default: "", null: false)

--- a/db/migrate/20160107213330_disallow_nulls_in_choreographers.rb
+++ b/db/migrate/20160107213330_disallow_nulls_in_choreographers.rb
@@ -1,4 +1,4 @@
-class DisallowNullsInChoreographers < ActiveRecord::Migration
+class DisallowNullsInChoreographers < ActiveRecord::Migration[4.2]
   def up
     change_column(:choreographers, :name, :string, default: "", null: false)
     Choreographer.all.each {|d| d.name ||= ""}

--- a/db/migrate/20160108213353_create_activities.rb
+++ b/db/migrate/20160108213353_create_activities.rb
@@ -1,4 +1,4 @@
-class CreateActivities < ActiveRecord::Migration
+class CreateActivities < ActiveRecord::Migration[4.2]
   def change
     create_table :activities do |t|
       t.integer    :index,                                   null: false

--- a/db/migrate/20160214041945_rewrite_gypsy_to_gyre.rb
+++ b/db/migrate/20160214041945_rewrite_gypsy_to_gyre.rb
@@ -1,4 +1,4 @@
-class RewriteGypsyToGyre < ActiveRecord::Migration
+class RewriteGypsyToGyre < ActiveRecord::Migration[4.2]
 
   def contraFigureRewrite (key, from, to)
     Dance.all.each do |d|

--- a/db/migrate/20170409141456_add_publish_to_dance.rb
+++ b/db/migrate/20170409141456_add_publish_to_dance.rb
@@ -1,4 +1,4 @@
-class AddPublishToDance < ActiveRecord::Migration
+class AddPublishToDance < ActiveRecord::Migration[4.2]
   def change
     add_column :dances, :publish, :boolean, default: true, null: false
   end

--- a/db/migrate/20170415114334_add_is_admin_to_user.rb
+++ b/db/migrate/20170415114334_add_is_admin_to_user.rb
@@ -1,4 +1,4 @@
-class AddIsAdminToUser < ActiveRecord::Migration
+class AddIsAdminToUser < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :admin, :boolean, default: false, null: false
   end

--- a/db/migrate/20170415114550_backfill_is_admin_in_user.rb
+++ b/db/migrate/20170415114550_backfill_is_admin_in_user.rb
@@ -1,4 +1,4 @@
-class BackfillIsAdminInUser < ActiveRecord::Migration
+class BackfillIsAdminInUser < ActiveRecord::Migration[4.2]
   def up
     User.find_by(id: 1)&.update!(admin: true)
   end

--- a/db/migrate/20170513114820_add_publish_and_website_to_choreographer.rb
+++ b/db/migrate/20170513114820_add_publish_and_website_to_choreographer.rb
@@ -1,4 +1,4 @@
-class AddPublishAndWebsiteToChoreographer < ActiveRecord::Migration
+class AddPublishAndWebsiteToChoreographer < ActiveRecord::Migration[4.2]
   def change
     add_column :choreographers, :publish, :integer
     add_column :choreographers, :website, :string

--- a/db/migrate/20170604212005_long_lines_add_forward_only.rb
+++ b/db/migrate/20170604212005_long_lines_add_forward_only.rb
@@ -1,6 +1,6 @@
 require 'jslibfigure'
 
-class LongLinesAddForwardOnly < ActiveRecord::Migration
+class LongLinesAddForwardOnly < ActiveRecord::Migration[4.2]
   def down
     raise "not implemented - its possible just not worth the time"
   end

--- a/db/migrate/20170607042254_hey_add_half.rb
+++ b/db/migrate/20170607042254_hey_add_half.rb
@@ -1,6 +1,6 @@
 require 'jslibfigure'
 
-class HeyAddHalf < ActiveRecord::Migration
+class HeyAddHalf < ActiveRecord::Migration[4.2]
   def down
     raise 'too lazy to implement down'
   end


### PR DESCRIPTION
Old migrations omitted the Rails version, which appears to be required
now (caused db:setup and db:migrate to error out).  Fix up using 4.2.