### PR TITLE
Add JSON download mode for dances.

### DIFF
--- a/app/views/dances/show.json.erb
+++ b/app/views/dances/show.json.erb
@@ -1,0 +1,1 @@
+<%= @dance.figures_json.html_safe %>

--- a/app/views/dances/show.json.erb
+++ b/app/views/dances/show.json.erb
@@ -1,1 +1,10 @@
-<%= @dance.figures_json.html_safe %>
+{
+  "id": <%= @dance.id.to_json.html_safe %>,
+  "title": <%= @dance.title.to_json.html_safe %>,
+  "choreographer_name": <%= @dance.choreographer.name.to_json.html_safe %>,
+  "start_type": <%= @dance.start_type.to_json.html_safe %>,
+  "preamble": <%= @dance.preamble.to_json.html_safe %>,
+  "figures": <%= @dance.figures_json.html_safe %>,
+  "notes": <%= @dance.notes.to_json.html_safe %>,
+  "hook": <%= @dance.hook.to_json.html_safe %>
+}


### PR DESCRIPTION
This PRs lets you easily download the figures for a dance you can access by appending `.json` to the URL like https://contradb.com/dances/2014.json . This makes it easier to access the same data that you can currently get by copying a dance and extracting the value from the `#dance-figures-json` element's value.

This does only include the figures. It might make sense to include the rest of the information about the dance and have the figures be just one property on a large object.